### PR TITLE
content and markup fixes

### DIFF
--- a/1941zepic-TEI-P5.xml
+++ b/1941zepic-TEI-P5.xml
@@ -19261,7 +19261,7 @@
          <entryFree ana="pavor">
             <hi rend="bold">pavor,</hi> <gram>oris, m.</gram> strah, drhat, strava</entryFree>
          <entryFree ana="pax">
-            <hi rend="bold">pax,</hi> <gram>pacis, f.</gram> 1) mir, mirovanje; (i n) pace u mirno doba; pacem agitare živjeti u miru. 2) dopuštenje, oproštenje (<hi rend="underline">pace tua</hi> s tvojim dopuštenjem)</entryFree>
+            <hi rend="bold">pax,</hi> <gram>pacis, f.</gram> 1) mir, mirovanje; <hi rend="underline">(in) pace</hi>, u mirno doba; <hi rend="underline">pacem agitare</hi>, živjeti u miru. 2) dopuštenje, oproštenje (<hi rend="underline">pace tua</hi> s tvojim dopuštenjem); milost božja</entryFree>
          <entryFree ana="peccatum">
             <hi rend="bold">peccatum,</hi> <gram>i, n.</gram> grijeh, pogreška, prestupak</entryFree>
          <entryFree ana="pecco">
@@ -23312,7 +23312,7 @@
          <entryFree ana="regionatim">
             <hi rend="bold">regionatim,</hi> <gram>adv.</gram> po kotarima</entryFree>
          <entryFree ana="regius">
-            <hi rend="bold">regius,</hi> <gram>adi.</gram> kraljevski, kraljev, carski (r. <hi rend="underline">bellum</hi> rat s kraljem); <hi rend="bold">regii,</hi> <gram>orum, m.</gram> kraljevska vojska; dvorani; <hi rend="bold">regia,</hi> <gram>ae, f.</gram> kraljevski dvor; prijestolnica</entryFree>
+            <hi rend="bold">regius,</hi> <gram>adi.</gram> kraljevski, kraljev, carski (<hi rend="underline">regius bellum</hi> rat s kraljem); <hi rend="bold">regii,</hi> <gram>orum, m.</gram> kraljevska vojska; dvorani; <hi rend="bold">regia,</hi> <gram>ae, f.</gram> kraljevski dvor; prijestolnica</entryFree>
          <entryFree ana="regnator">
             <hi rend="bold">regnator,</hi> <gram>oris, m.</gram> kralj, vladar, gospodar</entryFree>
          <entryFree ana="regnatrix">
@@ -23800,7 +23800,7 @@
          <entryFree ana="retundo">
             <hi rend="bold">re-tundo,</hi> <gram>tudi, tusum (tunsum), 3.</gram> otisnuti natrag, zauzdati; otupiti, ugušiti</entryFree>
          <entryFree ana="reus">
-            <hi rend="bold">reus,</hi> <gram>i, m.</gram> i <hi rend="bold">rea,</hi> <gram>ae, f.</gram> okrivljenik, okrivljenica, krivac, <hi rend="underline">pl. rei</hi> parbenici; <hi rend="underline">alqm reum facere</hi> optužiti</entryFree>
+            <hi rend="bold">reus,</hi> <gram>i, m.</gram> i <hi rend="bold">rea,</hi> <gram>ae, f.</gram> okrivljenik, okrivljenica, krivac, pl. <hi rend="underline">rei</hi> parbenici; <hi rend="underline">alqm reum facere</hi> optužiti</entryFree>
          <entryFree ana="revalesco">
             <hi rend="bold">re-valesco,</hi> <gram>lui, 3.</gram> ponovo ozdraviti, ponovo ojačati</entryFree>
          <entryFree ana="reveho">
@@ -23880,7 +23880,7 @@
          <entryFree ana="ricinium">
             <hi rend="bold">ricinium,</hi> <gram>ii, n.</gram> mala povezača, mala koprena</entryFree>
          <entryFree ana="rictus">
-            <hi rend="bold">rictus,</hi> <gram>us, m.</gram> i <hi rend="bold">rictum,</hi> <gram>i, n.</gram> usta na smijeh razvaljena, zjalo; otvoreno ždrijelo (životinje</entryFree>
+            <hi rend="bold">rictus,</hi> <gram>us, m.</gram> i <hi rend="bold">rictum,</hi> <gram>i, n.</gram> usta na smijeh razvaljena, zjalo; otvoreno ždrijelo (životinje)</entryFree>
          <entryFree ana="rideo">
             <hi rend="bold">rideo,</hi> <gram>risi, risum, 2.</gram> 1) intr, smijati se; smiješiti se; veseo se prikazivati, biti vesela lica. 2) tranz. podsmijevati se, podrugivati se (<hi rend="underline">alqm, alqd</hi>)</entryFree>
          <entryFree ana="ridicularia">
@@ -25641,7 +25641,7 @@
          <entryFree ana="spatiosus">
             <hi rend="bold">spatiosus,</hi> <gram>adi.</gram> prostran, širok, dug</entryFree>
          <entryFree ana="spatium">
-            <hi rend="bold">spatium,</hi> <gram>ii, n.</gram> 1) prostor, mjesto, obujam, veličina. 2) daljina, razmak; <hi rend="underline">abesse aequo spatio</hi> isto toliko biti udaljen. 3) trkalište.4) šetnja, šetalište. 5) vrijeme, rok, prilika, trajanje vremena, često se i ne prevodi, s.<hi rend="underline">diei</hi> ono dana, <hi rend="underline">hoc spatio</hi> u to vrijeme, uto; <hi rend="underline">nullum s. dare alicuius rei</hi> ne dati vremena za što; <hi rend="underline">spatio interiecto</hi> nakon nekog vremena</entryFree>
+            <hi rend="bold">spatium,</hi> <gram>ii, n.</gram> 1) prostor, mjesto, obujam, veličina. 2) daljina, razmak; <hi rend="underline">abesse aequo spatio</hi>, isto toliko biti udaljen. 3) trkalište. 4) šetnja, šetalište. 5) vrijeme, rok, prilika, trajanje vremena, često se i ne prevodi, <hi rend="underline">spatium diei</hi>, ono dana, <hi rend="underline">hoc spatio</hi>, u to vrijeme, uto; <hi rend="underline">nullum spatium dare alicuius rei</hi>, ne dati vremena za što; <hi rend="underline">spatio interiecto</hi>, nakon nekog vremena (i: u nekoj udaljenosti)</entryFree>
          <entryFree ana="species">
             <hi rend="bold">species,</hi> <gram>ei, f.</gram> 1) gledanje, pogled (<hi rend="underline">prima specie</hi> na prvi pogled) 2) pojava (<hi rend="underline">s. praebere alicuius rei</hi> graditi se kao da; <hi rend="underline">s. ridentis praebere</hi> držati se na smijeh); priviđenje, san; misao, pojam. 3) prilika, oblik (s. <hi rend="underline">libertatis</hi> sloboda izvana); sjajnost; ljepota, divota; izlika, <hi rend="underline">per speciem, specie</hi> na izliku, kao da; <hi rend="underline">in speciem</hi> pričinjavajući se 4) prilika, slika. 5) vrsta</entryFree>
          <entryFree ana="specillum">
@@ -31786,13 +31786,19 @@
          <entryFree ana="Peducaeus">
             <hi rend="bold">Peducaeus,</hi> <gram>i, m.</gram> Peducej, ime rimske obitelji</entryFree>
          <entryFree ana="Pegasus">
-            <hi rend="bold">Pegasus,</hi> <gram>i, m.</gram> Pegaz, krilati konj, simbol pjesnika; <hi rend="bold">Pegaseus,</hi> <gram>adi. Pegazov <hi rend="bold">Pelasgi,</hi> orum, m.</gram> Pelazgi, prastanovnici Grčke</entryFree>
+            <hi rend="bold">Pegasus,</hi> <gram>i, m.</gram> Pegaz, krilati konj, simbol pjesnika; <hi rend="bold">Pegaseus,</hi> <gram>adi.</gram> Pegazov</entryFree>
+         <entryFree ana="Pelasgus">
+             <hi rend="bold">Pelasgi,</hi> <gram>orum, m.</gram> Pelazgi, prastanovnici Grčke</entryFree>
          <entryFree ana="Peleus">
             <hi rend="bold">Peleus,</hi> <gram>ei, m.</gram> Pelej, otac Ahilejev, <hi rend="bold">Pelides,</hi> <gram>ae, m.</gram>. sin Pelejev</entryFree>
          <entryFree ana="Pelias">
             <hi rend="bold">Pelias,</hi> <gram>ae, m.</gram> Pelija, kralj u Jolku, mitsko lice</entryFree>
          <entryFree ana="Pelion">
-            <hi rend="bold">Pelion,</hi> <gram>ii, n.</gram> Pelion, gora u Tesaliji <hi rend="bold">Pella,</hi> <gram>ae, f.</gram> Pela, grad u Makedoniji <hi rend="bold">Peloponnesus,</hi> <gram>i, f.</gram> Peloponez, grčki poluotok, sada Morea; <hi rend="bold">Peloponnesiacus i Peloponnesius,</hi> <gram>adi. peloponeski, <hi rend="bold">Peloponnesii,</hi> orum, m.</gram> Peloponežani</entryFree>
+            <hi rend="bold">Pelion,</hi> <gram>ii, n.</gram> Pelion, gora u Tesaliji</entryFree>
+         <entryFree ana="Pella">
+            <hi rend="bold">Pella,</hi> <gram>ae, f.</gram> Pela, grad u Makedoniji</entryFree>
+         <entryFree ana="Peloponnesus">
+            <hi rend="bold">Peloponnesus,</hi> <gram>i, f.</gram> Peloponez, grčki poluotok, sada Morea; <hi rend="bold">Peloponnesiacus</hi> i <hi rend="bold">Peloponnesius,</hi> <gram>adi.</gram> peloponeski, <hi rend="bold">Peloponnesii,</hi> <gram>orum, m.</gram> Peloponežani</entryFree>
          <entryFree ana="Pelusium">
             <hi rend="bold">Pelusium,</hi> <gram>ii, n.</gram> Peluzij, grad u Egiptu</entryFree>
          <entryFree ana="Penates">
@@ -31872,7 +31878,7 @@
          <entryFree ana="Phoebe">
             <hi rend="bold">Phoebe,</hi> <gram>es, f.</gram> Feba, 1) Dijana kao božica mjeseca; 2) žensko ime</entryFree>
          <entryFree ana="Phoebes">
-            <hi rend="bold">Phoebes,</hi> <gram>i, m.</gram> Feb, pridjevak Apolona, boga sunca; <hi rend="bold">Phoebeus,</hi> <gram>adi. Febov <hi rend="bold">Phoenices,</hi> um, m.</gram> Feničani; <hi rend="bold">Phoenicius,</hi> <gram>adi. fenički; <hi rend="bold">Phoenicia,</hi> ae, f.</gram> Fenikija</entryFree>
+            <hi rend="bold">Phoebes,</hi> <gram>i, m.</gram> Feb, pridjevak Apolona, boga sunca; <hi rend="bold">Phoebeus,</hi> <gram>adi.</gram> Febov <hi rend="bold">Phoenices,</hi> <gram>um, m.</gram> Feničani; <hi rend="bold">Phoenicius,</hi> <gram>adi.</gram> fenički; <hi rend="bold">Phoenicia,</hi> <gram>ae, f.</gram> Fenikija</entryFree>
          <entryFree ana="Phormio">
             <hi rend="bold">Phormio,</hi> <gram>onis, m.</gram> Formion, čankoliz u istoimenoj Terencijevoj komediji</entryFree>
          <entryFree ana="Phraates">
@@ -31880,7 +31886,7 @@
          <entryFree ana="Phrixus">
             <hi rend="bold">Phrixus,</hi> <gram>i, m.</gram> Friks, mitsko lice, brat Helin</entryFree>
          <entryFree ana="Phrygia">
-            <hi rend="bold">Phrygia,</hi> <gram>ae, f.</gram> Frigija, pokrajina u Maloj Aziji; <hi rend="bold">Phrygius,</hi> <gram>adi. frigijski; <hi rend="bold">Phryges,</hi> um, m.</gram> Frigijci</entryFree>
+            <hi rend="bold">Phrygia,</hi> <gram>ae, f.</gram> Frigija, pokrajina u Maloj Aziji; <hi rend="bold">Phrygius,</hi> <gram>adi.</gram> frigijski; <hi rend="bold">Phryges,</hi> <gram>um, m.</gram> Frigijci</entryFree>
          <entryFree ana="Phryne">
             <hi rend="bold">Phryne,</hi> <gram>es, f.</gram> Frina, zbog svoje ljepote poznata hetera u Ateni</entryFree>
          <entryFree ana="Phthia">
@@ -31962,7 +31968,7 @@
          <entryFree ana="Pomptinum">
             <hi rend="bold">Pomptinum,</hi> <gram>i, n.</gram> Pomptin, predio u Laciju; <hi rend="bold">Pomptinus,</hi> <gram>adi.</gram> pomptinski</entryFree>
          <entryFree ana="Pontes">
-            <hi rend="bold">Pontes,</hi> <gram>i, m.</gram> 1) Pont, Crno more; 2) pokrajina Pont; <hi rend="bold">Ponticus,</hi> <gram>adi. pontski <hi rend="bold">Popilius,</hi> ii, m.</gram> Popilije, ime rimskog roda</entryFree>
+            <hi rend="bold">Pontes,</hi> <gram>i, m.</gram> 1) Pont, Crno more; 2) pokrajina Pont; <hi rend="bold">Ponticus,</hi> <gram>adi.</gram> pontski <hi rend="bold">Popilius,</hi> <gram>ii, m.</gram> Popilije, ime rimskog roda</entryFree>
          <entryFree ana="Poplicola">
             <hi rend="bold">Poplicola,</hi> <gram>ae, m.</gram> Poplikola, prijatelj naroda, pridjevak Gaja Valerija</entryFree>
          <entryFree ana="Poppaeus">
@@ -31970,7 +31976,7 @@
          <entryFree ana="Porcius">
             <hi rend="bold">Porcius,</hi> <gram>ii, m.</gram> Porcije, ime rimskog roda</entryFree>
          <entryFree ana="Porsena">
-            <hi rend="bold">Porsena</hi> <gram>(Porsenna), ae, m.</gram> Porzena, kralj etrurski</entryFree>
+            <hi rend="bold">Porsena</hi> (Porsenna), <gram>ae, m.</gram> Porzena, kralj etrurski</entryFree>
          <entryFree ana="Porus">
             <hi rend="bold">Porus,</hi> <gram>i, m.</gram> Por, kralj u Indiji</entryFree>
          <entryFree ana="Posidonius">
@@ -31982,7 +31988,7 @@
          <entryFree ana="Praxiteles">
             <hi rend="bold">Praxiteles,</hi> <gram>is, m.</gram> Praksitel, grčki kipar</entryFree>
          <entryFree ana="Priamus">
-            <hi rend="bold">Priamus,</hi> <gram>i, m.</gram> Prijam, kralj trojanski; <hi rend="bold">Priameius,</hi> <gram>adi. Prijamov; <hi rend="bold">Priamides,</hi> ae, m.</gram> potomak Prijamov</entryFree>
+            <hi rend="bold">Priamus,</hi> <gram>i, m.</gram> Prijam, kralj trojanski; <hi rend="bold">Priameius,</hi> <gram>adi.</gram> Prijamov; <hi rend="bold">Priamides,</hi> <gram>ae, m.</gram> potomak Prijamov</entryFree>
          <entryFree ana="Priapus">
             <hi rend="bold">Priapus,</hi> <gram>i, m.</gram> Prijap, bog plodnosti</entryFree>
          <entryFree ana="Procas">
@@ -31998,7 +32004,7 @@
          <entryFree ana="Prodicus">
             <hi rend="bold">Prodicus,</hi> <gram>i, m.</gram> Prodik, grčki sofist</entryFree>
          <entryFree ana="Prometheus">
-            <hi rend="bold">Prometheus,</hi> <gram>i, m.</gram> Prometej; sin Japetov; <hi rend="bold">Prometheus,</hi> <gram>adi. prometejski <hi rend="bold">Propertius,</hi> ii, m.</gram> Propercije, rimski pjesnik</entryFree>
+            <hi rend="bold">Prometheus,</hi> <gram>i, m.</gram> Prometej; sin Japetov; <hi rend="bold">Prometheus,</hi> <gram>adi.</gram> prometejski <hi rend="bold">Propertius,</hi> <gram>ii, m.</gram> Propercije, rimski pjesnik</entryFree>
          <entryFree ana="Propontis">
             <hi rend="bold">Propontis,</hi> <gram>idis, f.</gram> Propontida, sada Mramorno more</entryFree>
          <entryFree ana="Proserpina">
@@ -32024,7 +32030,7 @@
          <entryFree ana="Pupius">
             <hi rend="bold">Pupius,</hi> <gram>ii, m.</gram> Pupije, rimski pisac tragedija</entryFree>
          <entryFree ana="Puteoli">
-            <hi rend="bold">Puteoli,</hi> <gram>orum, m.</gram> Puteoli, kampanski grad, danas Pozzuoli; <hi rend="bold">Puteolanus,</hi> <gram>adi. puteolski; <hi rend="bold">Puteolanus,</hi> i, m.</gram> stanovnik Puteola</entryFree>
+            <hi rend="bold">Puteoli,</hi> <gram>orum, m.</gram> Puteoli, kampanski grad, danas Pozzuoli; <hi rend="bold">Puteolanus,</hi> <gram>adi.</gram> puteolski; <hi rend="bold">Puteolanus,</hi> <gram>i, m.</gram> stanovnik Puteola</entryFree>
          <entryFree ana="Pydna">
             <hi rend="bold">Pydna,</hi> <gram>ae, f.</gram> Pidna, grad u Makedoniji; <hi rend="bold">Pydnaei,</hi> <gram>orum, m.</gram> stanovnici. Pidne</entryFree>
          <entryFree ana="Pygmaeus">
@@ -32048,9 +32054,9 @@
          <entryFree ana="Pythagoras">
             <hi rend="bold">Pythagoras,</hi> <gram>ae, m.</gram> Pitagora, grčki filozof; <hi rend="bold">Pythagoricus</hi> i <hi rend="bold">Pythagoreus,</hi> <gram>adi.</gram> Pitagorin, pitagorski; <hi rend="bold">Pythagoricus,</hi> <gram>i, m.</gram> i <hi rend="bold">Pythagoreus,</hi> <gram>i, m.</gram> Pitagorovac, pristaša Pitagorin</entryFree>
          <entryFree ana="Pytho">
-            <hi rend="bold">Pytho,</hi> <gram>us, f.</gram> Pit, staro ime za Delfe; <hi rend="bold">Pythicus,</hi> <gram>adi. pitijski; <hi rend="bold">Pythia,</hi> orum, n.</gram> Pitijske igre</entryFree>
+            <hi rend="bold">Pytho,</hi> <gram>us, f.</gram> Pit, staro ime za Delfe; <hi rend="bold">Pythicus,</hi> <gram>adi.</gram> pitijski; <hi rend="bold">Pythia,</hi> <gram>orum, n.</gram> Pitijske igre</entryFree>
          <entryFree ana="Q.">
-            <hi rend="bold">Q.</hi> <gram>= <hi rend="bold">Quintus,</hi> i, m.</gram> Kvinto, rimsko ime</entryFree>
+            <hi rend="bold">Q.</hi> = <hi rend="bold">Quintus,</hi> <gram>i, m.</gram> Kvinto, rimsko ime</entryFree>
          <entryFree ana="Quadi">
             <hi rend="bold">Quadi,</hi> <gram>orum, m.</gram> Kvadi, germansko pleme</entryFree>
          <entryFree ana="Quintilianus">
@@ -32060,7 +32066,7 @@
          <entryFree ana="Quietus">
             <hi rend="bold">Quietus,</hi> <gram>i, m.</gram> Kvinto, rimsko ime</entryFree>
          <entryFree ana="Quirinalis">
-            <hi rend="bold">Quirinalis</hi> <gram>(collis), is, m.</gram> Kvirinal, ime brežuljka u Rimu; <hi rend="bold">Quirinalia,</hi> <gram>ium, n.</gram> Kvirinalije, svetkovina u čast Romula</entryFree>
+            <hi rend="bold">Quirinalis</hi> (collis), <gram>is, m.</gram> Kvirinal, ime brežuljka u Rimu; <hi rend="bold">Quirinalia,</hi> <gram>ium, n.</gram> Kvirinalije, svetkovina u čast Romula</entryFree>
          <entryFree ana="Quirinus">
             <hi rend="bold">Quirinus,</hi> <gram>i, m.</gram> Kvirin, ime Romula kao boga</entryFree>
          <entryFree ana="Quirites">
@@ -32082,38 +32088,43 @@
          <entryFree ana="Regium">
             <hi rend="bold">Regium,</hi> <gram>ii, n.</gram> Regij, 1) grad u Galiji Cispadanskoj (Reggio d' Emilia); 2) današnji Reggio di Calabria</entryFree>
          <entryFree ana="Regulus">
-            <hi rend="bold">Regulus,</hi> <gram>i, m.</gram> Regul. rimsko obiteljsko ime</entryFree>
+            <hi rend="bold">Regulus,</hi> <gram>i, m.</gram> Regul, rimsko obiteljsko ime</entryFree>
          <entryFree ana="Remi">
-            <hi rend="bold">Remi,</hi> <gram>orum, m.</gram> Remljani. galsko pleme u okolici Rheimsa</entryFree>
+            <hi rend="bold">Remi,</hi> <gram>orum, m.</gram> Remljani, galsko pleme u okolici Rheimsa</entryFree>
          <entryFree ana="Remus">
-            <hi rend="bold">Remus,</hi> <gram>i, m.</gram> Rem. brat Romulov</entryFree>
+            <hi rend="bold">Remus,</hi> <gram>i, m.</gram> Rem, brat Romulov</entryFree>
          <entryFree ana="Rhadamanthus">
             <hi rend="bold">Rhadamanthus,</hi> <gram>i, m.</gram> Radamant, sudac u podzemlju</entryFree>
          <entryFree ana="Rhamnus">
             <hi rend="bold">Rhamnus,</hi> <gram>unti, f.</gram> Ramnunt, mjesto u Africi</entryFree>
          <entryFree ana="Rhea">
-            <hi rend="bold">Rhea</hi> <gram>(Rea), ae, f.</gram> Rea. staroitalsko žensko ime: <hi rend="bold">Rea Silvia,</hi> mati Romula i Rema</entryFree>
+            <hi rend="bold">Rhea</hi> (Rea), <gram>ae, f.</gram> Rea, staroitalsko žensko ime: <hi rend="bold">Rea Silvia,</hi> mati Romula i Rema</entryFree>
          <entryFree ana="Rhenus">
             <hi rend="bold">Rhenus,</hi> <gram>i, m.</gram> Rajna</entryFree>
          <entryFree ana="Rhesus">
-            <hi rend="bold">Rhesus,</hi> <gram>i, m.</gram> Rez. trački kralj, mitsko lice</entryFree>
+            <hi rend="bold">Rhesus,</hi> <gram>i, m.</gram> Rez, trački kralj, mitsko lice</entryFree>
          <entryFree ana="Rhodanus">
-            <hi rend="bold">Rhodanus,</hi> <gram>i, m.</gram> Rodan (Rona. Rhone), rijeka u Galiji (Francuskoj) <hi rend="bold">Rhodope,</hi> <gram>es, f.</gram> Rodopa, gora u Trakiji (sada Rodopske planine); <hi rend="bold">Rhodopeius,</hi> <gram>adi.</gram> rodopski = trački</entryFree>
+            <hi rend="bold">Rhodanus,</hi> <gram>i, m.</gram> Rodan (Rona, Rhone), rijeka u Galiji (Francuskoj)</entryFree>
+         <entryFree ana="Rhodope">
+            <hi rend="bold">Rhodope,</hi> <gram>es, f.</gram> Rodopa, gora u Trakiji (sada Rodopske planine)</entryFree>
+         <entryFree ana="Rhodopeius">
+            <hi rend="bold">Rhodopeius,</hi> <gram>adi.</gram> rodopski = trački</entryFree>
          <entryFree ana="Rhodus">
-            <hi rend="bold">Rhodus</hi> <gram>ili <hi rend="bold">Rhodos,</hi> i, f.</gram> Rod, otok blizu maloazijske obale: <hi rend="bold">Rhodius,</hi> <gram>adi. rodski; <hi rend="bold">Rhodius,</hi> ii, m.</gram> Rođanin, stanovnik otoka Roda</entryFree>
+            <hi rend="bold">Rhodus</hi> ili <hi rend="bold">Rhodos,</hi> <gram>i, f.</gram> Rod, otok blizu maloazijske obale: <hi rend="bold">Rhodius,</hi> <gram>adi.</gram> rodski; <hi rend="bold">Rhodius,</hi> <gram>ii, m.</gram> Rođanin, stanovnik otoka Roda</entryFree>
          <entryFree ana="Rhoeteum">
-            <hi rend="bold">Rhoeteum,</hi> <gram>i, n.</gram> Retej, rt i grad u Troadi</entryFree>
+            <hi rend="bold">Rhoeteum,</hi> <gram>i, n.</gram> Retej, rt i grad u Troadi; Retejsko more u Troadi</entryFree>
          <entryFree ana="Roma">
-            <hi rend="bold">Roma,</hi> <gram>ae, f.</gram> Rim; <hi rend="bold">Romanus,</hi> <gram>adi. rimski; <hi rend="bold">Romanus,</hi> i, m.</gram> Rimljanin: <hi rend="bold">Romana,</hi> <gram>ae, f.</gram> Rimljanka</entryFree>
+            <hi rend="bold">Roma,</hi> <gram>ae, f.</gram> Rim; <hi rend="bold">Romanus,</hi> <gram>adi.</gram> rimski; <hi rend="bold">Romanus,</hi> <gram>i, m.</gram> Rimljanin: <hi rend="bold">Romana,</hi> <gram>ae, f.</gram> Rimljanka</entryFree>
          <entryFree ana="Romulus">
-            <hi rend="bold">Romulus,</hi> <gram>i, m.</gram> Romul. prvi kralj rimski </entryFree>
-            <entryFree ana="Roscius"><hi rend="bold">Roscius,</hi> <gram>ii, m.</gram> Roscije. ime rimskog roda</entryFree>
+            <hi rend="bold">Romulus,</hi> <gram>i, m.</gram> Romul, prvi kralj rimski </entryFree>
+         <entryFree ana="Roscius">
+            <hi rend="bold">Roscius,</hi> <gram>ii, m.</gram> Roscije, ime rimskog roda</entryFree>
          <entryFree ana="Roxane">
             <hi rend="bold">Roxane,</hi> <gram>es, f.</gram> Roksana, žena Aleksandra Velikoga</entryFree>
          <entryFree ana="Rubico">
             <hi rend="bold">Rubico,</hi> <gram>onis, m.</gram> Rubikon, rijeka a Italiji</entryFree>
          <entryFree ana="Rudiae">
-            <hi rend="bold">Rudiae</hi> <gram>arum, f.</gram> Rudija, grad u Kalabriji; <hi rend="bold">Rudinus,</hi> <gram>adi. rudijski; <hi rend="bold">Rudinus,</hi> i, m.</gram> Rudijac</entryFree>
+            <hi rend="bold">Rudiae</hi> <gram>arum, f.</gram> Rudija, grad u Kalabriji; <hi rend="bold">Rudinus,</hi> <gram>adi.</gram> rudijski; <hi rend="bold">Rudinus,</hi> <gram>i, m.</gram> Rudijac</entryFree>
          <entryFree ana="Ruminalis">
             <hi rend="bold">Ruminalis,</hi> <gram>e, adi.</gram> ruminalski, koji pripada Rumini, rimskoj božici, zaštitnici dojenčadi</entryFree>
          <entryFree ana="Rupilius">
@@ -32133,11 +32144,17 @@
          <entryFree ana="Sabelli">
             <hi rend="bold">Sabelli,</hi> <gram>orum, m.</gram> Sabelci, staro ime za Sabince; <hi rend="bold">Sabellus,</hi> <gram>adi.</gram> sabelski, sabinski</entryFree>
          <entryFree ana="Sabinus">
-            <hi rend="bold">Sabinus,</hi> <gram>i, m.</gram> Sabinac; <hi rend="bold">Sabinus,</hi> <gram>adi. sabinski; <hi rend="bold">Sabinum,</hi> i, n.</gram> sabinsko vino <hi rend="bold">Saguntum,</hi> <gram>i, n.</gram> Sagunt, grad u Hispaniji; <hi rend="bold">Saguntinus,</hi> <gram>adi. saguntski; <hi rend="bold">Saguntinus,</hi> i, m.</gram> Sagunćanin</entryFree>
+            <hi rend="bold">Sabinus,</hi> <gram>i, m.</gram> Sabinac; <hi rend="bold">Sabinus,</hi> <gram>adi.</gram> sabinski; <hi rend="bold">Sabinum,</hi> <gram>i, n.</gram> sabinsko vino</entryFree>
+         <entryFree ana="Saena">
+            <hi rend="bold">Saena,</hi> <gram>ae, f.</gram> Sena (Siena), grad u Umbriji</entryFree>
+         <entryFree ana="Saguntum">
+            <hi rend="bold">Saguntum,</hi> <gram>i, n.</gram> Sagunt, grad u Hispaniji; <hi rend="bold">Saguntinus,</hi> <gram>adi.</gram> saguntski; <hi rend="bold">Saguntinus,</hi> <gram>i, m.</gram> Sagunćanin</entryFree>
          <entryFree ana="Salamis">
-            <hi rend="bold">Salamis,</hi> <gram>inis, f.</gram> Salamina, otok u Saronskom zalivu u Grčkoj; <hi rend="bold">Saliminius,</hi> <gram>adi. salaminski; <hi rend="bold">Salaminius,</hi> ii, m.</gram> Salaminjanin</entryFree>
+            <hi rend="bold">Salamis,</hi> <gram>inis, f.</gram> Salamina, otok u Saronskom zalivu u Grčkoj; <hi rend="bold">Saliminius,</hi> <gram>adi.</gram> salaminski; <hi rend="bold">Salaminius,</hi> <gram>ii, m.</gram> Salaminjanin</entryFree>
          <entryFree ana="Salii">
-            <hi rend="bold">Salii,</hi> <gram>orum, m.</gram> Salijci, zbor Martovih svećenika; <hi rend="bold">Saliaris,</hi> <gram>e, adi. salijski <hi rend="bold">Sallinator,</hi> oris, m.</gram> Salinator, rimski pridjevak</entryFree>
+            <hi rend="bold">Salii,</hi> <gram>orum, m.</gram> Salijci, zbor Martovih svećenika; <hi rend="bold">Saliaris,</hi> <gram>e, adi.</gram> salijski</entryFree>
+         <entryFree ana="Salinator">
+            <hi rend="bold">Salinator,</hi> <gram>oris, m.</gram> Salinator (solar), rimski pridjevak</entryFree>
          <entryFree ana="Sallustius">
             <hi rend="bold">Sallustius,</hi> <gram>ii, m.</gram> 1) ime rimskog roda; 2) rimski pisac; <hi rend="bold">Sallustianus,</hi> <gram>adi.</gram> Salustijev</entryFree>
          <entryFree ana="Salmoneus">
@@ -32161,11 +32178,13 @@
          <entryFree ana="Sardes">
             <hi rend="bold">Sardes</hi> <gram>(Sardis), ium, f.</gram> Sard, grad u Lidiji; <hi rend="bold">Sardiani,</hi> <gram>orum, m.</gram> stanovnici Sarda</entryFree>
          <entryFree ana="Sardinia">
-            <hi rend="bold">Sardinia,</hi> <gram>ae, f.</gram> Sardinija, otok; <hi rend="bold">Sardiniensis,</hi> <gram>e, adi.</gram> sardinski; <hi rend="bold">Sardi,</hi> orum, ~n. Sardinci</entryFree>
+            <hi rend="bold">Sardinia,</hi> <gram>ae, f.</gram> Sardinija, otok; <hi rend="bold">Sardiniensis,</hi> <gram>e, adi.</gram> sardinski; <hi rend="bold">Sardi,</hi> <gram>orum, m.</gram> Sardinci</entryFree>
          <entryFree ana="Sarmatae">
-            <hi rend="bold">Sarmatae,</hi> <gram>arum, m.</gram> Sarmaćani, stanovnici današnje poljsko-ruske nizine <hi rend="bold">Sarpedon,</hi> <gram>onis, m.</gram> Sarpedon, sin Jupiterov, mitsko lice</entryFree>
+            <hi rend="bold">Sarmatae,</hi> <gram>arum, m.</gram> Sarmaćani, stanovnici današnje poljsko-ruske nizine</entryFree>
+         <entryFree ana="Sarpedon">
+            <hi rend="bold">Sarpedon,</hi> <gram>onis, m.</gram> Sarpedon, sin Jupiterov, mitsko lice</entryFree>
          <entryFree ana="Saturnus">
-            <hi rend="bold">Saturnus,</hi> <gram>i, m.</gram> Saturn, rimski bog usjeva; <hi rend="bold">Saturnius,</hi> <gram>adi. Saturnov; <hi rend="bold">Saturnius,</hi> ii, m.</gram> sin Saturnov, Jupiter; <hi rend="bold">Saturnalia,</hi> <gram>orum, n.</gram> svetkovina u čast Saturnu</entryFree>
+            <hi rend="bold">Saturnus,</hi> <gram>i, m.</gram> Saturn, rimski bog usjeva; <hi rend="bold">Saturnius,</hi> <gram>adi.</gram> Saturnov; <hi rend="bold">Saturnius,</hi> <gram>ii, m.</gram> sin Saturnov, Jupiter; <hi rend="bold">Saturnalia,</hi> <gram>orum, n.</gram> svetkovina u čast Saturnu</entryFree>
          <entryFree ana="Scaevola">
             <hi rend="bold">Scaevola,</hi> <gram>ae, m.</gram> Scevola (Ljevoruki), pridjevak Mucijev</entryFree>
          <entryFree ana="Scamander">
@@ -32177,11 +32196,15 @@
          <entryFree ana="Scythae">
             <hi rend="bold">Scythae,</hi> <gram>arum, m.</gram> Skiti; <hi rend="bold">Scythicus,</hi> <gram>adi.</gram> skitski</entryFree>
          <entryFree ana="Segesta">
-            <hi rend="bold">Segesta,</hi> <gram>ae, f.</gram> Segesta, grad na Siciliji; <hi rend="bold">Segestanus,</hi> <gram>adi. segestanski; <hi rend="bold">Segestanus,</hi> i, m.</gram> stanovnik Segeste</entryFree>
+            <hi rend="bold">Segesta,</hi> <gram>ae, f.</gram> Segesta, grad na Siciliji; <hi rend="bold">Segestanus,</hi> <gram>adi.</gram> segestanski; <hi rend="bold">Segestanus,</hi> <gram>i, m.</gram> stanovnik Segeste</entryFree>
          <entryFree ana="Segusiavi">
             <hi rend="bold">Segusiavi,</hi> <gram>orum, m.</gram> Seguzijavci, narod galski</entryFree>
          <entryFree ana="Seianus">
-            <hi rend="bold">Seianus,</hi> <gram>i, m.</gram> Sejan, Tiberijev ljubimac <hi rend="bold">Seius,</hi> <gram>i, m.</gram> Sej, ime rimskog roda <hi rend="bold">Seleucia,</hi> <gram>ae, f.</gram> Seleukija, ime više gradova u Aziji</entryFree>
+            <hi rend="bold">Seianus,</hi> <gram>i, m.</gram> Sejan, Tiberijev ljubimac
+         <entryFree ana="Seius">
+            <hi rend="bold">Seius,</hi> <gram>i, m.</gram> Sej, ime rimskog roda
+         <entryFree ana="Seleucia">
+            <hi rend="bold">Seleucia,</hi> <gram>ae, f.</gram> Seleukija; ime više gradova u Aziji</entryFree>
          <entryFree ana="Seleucus">
             <hi rend="bold">Seleucus,</hi> <gram>i, m.</gram> Seleuk, vojskovođa Aleksandra Velikoga</entryFree>
          <entryFree ana="Semele">

--- a/1941zepic-TEI-P5.xml
+++ b/1941zepic-TEI-P5.xml
@@ -32200,9 +32200,9 @@
          <entryFree ana="Segusiavi">
             <hi rend="bold">Segusiavi,</hi> <gram>orum, m.</gram> Seguzijavci, narod galski</entryFree>
          <entryFree ana="Seianus">
-            <hi rend="bold">Seianus,</hi> <gram>i, m.</gram> Sejan, Tiberijev ljubimac
+            <hi rend="bold">Seianus,</hi> <gram>i, m.</gram> Sejan, Tiberijev ljubimac</entryFree>
          <entryFree ana="Seius">
-            <hi rend="bold">Seius,</hi> <gram>i, m.</gram> Sej, ime rimskog roda
+            <hi rend="bold">Seius,</hi> <gram>i, m.</gram> Sej, ime rimskog roda</entryFree>
          <entryFree ana="Seleucia">
             <hi rend="bold">Seleucia,</hi> <gram>ae, f.</gram> Seleukija; ime više gradova u Aziji</entryFree>
          <entryFree ana="Seleucus">


### PR DESCRIPTION
This pull request contains two types of changes:

1. fixes of typos and rare mark-up errors in the first part of the dictionary.
1. fixes of massive mark-up errors, most frequent are erroneously joined articles and unclosed `gram` tags, in the second part "Nomina propria".

Though, it's not a result of consecutive proofreading, but the mistakes noted on random look up in the dictionary. Second part still needs serious checking of mark-up.